### PR TITLE
Implement Oracle API dispatch

### DIFF
--- a/src/main/java/com/coinbase/exchange/api/authenticated/oracle/OracleApi.java
+++ b/src/main/java/com/coinbase/exchange/api/authenticated/oracle/OracleApi.java
@@ -1,0 +1,9 @@
+package com.coinbase.exchange.api.authenticated.oracle;
+
+import com.coinbase.exchange.model.oracle.OracleRequest;
+import com.coinbase.exchange.model.response.Response;
+
+public interface OracleApi {
+
+    Response getOracle(final OracleRequest oracleRequest);
+}

--- a/src/main/java/com/coinbase/exchange/api/authenticated/oracle/OracleApiImpl.java
+++ b/src/main/java/com/coinbase/exchange/api/authenticated/oracle/OracleApiImpl.java
@@ -1,0 +1,19 @@
+package com.coinbase.exchange.api.authenticated.oracle;
+
+import com.coinbase.exchange.api.resource.Resource;
+import com.coinbase.exchange.enrichment.Enricher;
+import com.coinbase.exchange.http.Http;
+import com.coinbase.exchange.http.HttpClient;
+import com.coinbase.exchange.model.oracle.OracleRequest;
+import com.coinbase.exchange.model.response.Response;
+
+public record OracleApiImpl(HttpClient httpClient, Enricher requestEnricher) implements OracleApi {
+
+    @Override
+    public Response getOracle(final OracleRequest oracleRequest) {
+        return httpClient.send(
+                requestEnricher.enrichRequest(
+                        oracleRequest, Http.GET, Resource.ORACLE))
+                .body();
+    }
+}

--- a/src/main/java/com/coinbase/exchange/api/resource/Resource.java
+++ b/src/main/java/com/coinbase/exchange/api/resource/Resource.java
@@ -32,7 +32,12 @@ public enum Resource {
      */
     ORDER               ("/orders",             expects(0)),
     ORDER_BY_API_KEY    ("/orders/{}",          expects(1)),
-    ORDER_BY_ORDER_ID   ("/orders/client::{}",  expects(1));
+    ORDER_BY_ORDER_ID   ("/orders/client::{}",  expects(1)),
+
+    /**
+     * Oracle API resources
+     */
+    ORACLE              ("/oracle",             expects(0));
 
     // resource URI format
     @Getter private final String uri;

--- a/src/main/java/com/coinbase/exchange/client/CoinbaseProClient.java
+++ b/src/main/java/com/coinbase/exchange/client/CoinbaseProClient.java
@@ -1,5 +1,6 @@
 package com.coinbase.exchange.client;
 
+import com.coinbase.exchange.model.oracle.OracleRequest;
 import com.coinbase.exchange.model.response.Response;
 import com.coinbase.exchange.model.account.AccountsRequest;
 import com.coinbase.exchange.model.order.CancelAllOrdersRequest;
@@ -35,4 +36,6 @@ public interface CoinbaseProClient {
     Response getOrderByApiKey(final GetOrderByApiKeyRequest getOrderByApiKeyRequest);
 
     Response getOrderByOrderId(final GetOrderByOrderIdRequest getOrderByOrderIdRequest);
+
+    Response getOracle(final OracleRequest oracleRequest);
 }

--- a/src/main/java/com/coinbase/exchange/client/CoinbaseProClientFactory.java
+++ b/src/main/java/com/coinbase/exchange/client/CoinbaseProClientFactory.java
@@ -1,6 +1,7 @@
 package com.coinbase.exchange.client;
 
 import com.coinbase.exchange.api.authenticated.accounts.AccountsApiImpl;
+import com.coinbase.exchange.api.authenticated.oracle.OracleApiImpl;
 import com.coinbase.exchange.api.authenticated.orders.OrdersApiImpl;
 import com.coinbase.exchange.authentication.Authentication;
 import com.coinbase.exchange.authentication.CoinbaseProAuthentication;
@@ -32,6 +33,7 @@ public final class CoinbaseProClientFactory {
 
         return new CoinbaseProClientImpl(
                 new AccountsApiImpl(httpClient, requestEnricher),
-                new OrdersApiImpl(httpClient, requestEnricher));
+                new OrdersApiImpl(httpClient, requestEnricher),
+                new OracleApiImpl(httpClient, requestEnricher));
     }
 }

--- a/src/main/java/com/coinbase/exchange/client/CoinbaseProClientImpl.java
+++ b/src/main/java/com/coinbase/exchange/client/CoinbaseProClientImpl.java
@@ -1,7 +1,9 @@
 package com.coinbase.exchange.client;
 
 import com.coinbase.exchange.api.authenticated.accounts.AccountsApi;
+import com.coinbase.exchange.api.authenticated.oracle.OracleApi;
 import com.coinbase.exchange.api.authenticated.orders.OrdersApi;
+import com.coinbase.exchange.model.oracle.OracleRequest;
 import com.coinbase.exchange.model.response.Response;
 import com.coinbase.exchange.model.account.AccountsRequest;
 import com.coinbase.exchange.model.order.CancelAllOrdersRequest;
@@ -14,17 +16,18 @@ import com.coinbase.exchange.model.order.ListOrdersRequest;
 import com.coinbase.exchange.model.order.MarketOrderRequest;
 import com.coinbase.exchange.util.Guard;
 import com.coinbase.exchange.util.request.Pagination;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class CoinbaseProClientImpl implements CoinbaseProClient {
 
     private final AccountsApi accountsApi;
     private final OrdersApi ordersApi;
+    private final OracleApi oracleApi;
 
-    CoinbaseProClientImpl(final AccountsApi accountsApi, final OrdersApi ordersApi) {
-        this.accountsApi = accountsApi;
-        this.ordersApi = ordersApi;
-    }
-    
+    // accounts
+
     @Override
     public Response listAccounts(final AccountsRequest accountsRequest) {
         Guard.nonNull(accountsRequest);
@@ -43,6 +46,8 @@ public class CoinbaseProClientImpl implements CoinbaseProClient {
         accountsRequest.setPagination(pagination);
         return accountsApi.getAccountHistory(accountsRequest);
     }
+
+    // orders
 
     @Override
     public Response placeLimitOrder(final LimitOrderRequest limitOrderRequest) {
@@ -91,5 +96,13 @@ public class CoinbaseProClientImpl implements CoinbaseProClient {
     public Response getOrderByOrderId(final GetOrderByOrderIdRequest getOrderByOrderIdRequest) {
         Guard.nonNull(getOrderByOrderIdRequest);
         return ordersApi.getOrderByOrderId(getOrderByOrderIdRequest);
+    }
+
+    // oracle
+
+    @Override
+    public Response getOracle(final OracleRequest oracleRequest) {
+        Guard.nonNull(oracleRequest);
+        return oracleApi.getOracle(oracleRequest);
     }
 }

--- a/src/main/java/com/coinbase/exchange/model/account/AccountsRequest.java
+++ b/src/main/java/com/coinbase/exchange/model/account/AccountsRequest.java
@@ -8,7 +8,6 @@ import lombok.Getter;
 /**
  * Requests for Coinbase Pro accounts API.
  */
-@Getter
 @Builder
 public class AccountsRequest extends BaseRequest {
 

--- a/src/main/java/com/coinbase/exchange/model/oracle/OracleRequest.java
+++ b/src/main/java/com/coinbase/exchange/model/oracle/OracleRequest.java
@@ -1,0 +1,9 @@
+package com.coinbase.exchange.model.oracle;
+
+import com.coinbase.exchange.model.request.BaseRequest;
+import lombok.Builder;
+
+@Builder
+public class OracleRequest extends BaseRequest {
+
+}


### PR DESCRIPTION
1. Oracle API dispatch (endpoint: `/oracle`) 
2. More featureful json post-processing

This is the bare minimum implementation for the Oracle API. Should add more user friendly features like getting a particular price in USD for a specific crypto. For example, to get the ETH-USD conversion:
```java
final Response response = coinbaseProClient.getOracle(OracleRequest.builder().build());
final BigDecimal ethPrice = new BigDecimal(
        response.process(PostProcessing.getJsonValueAsString("/prices/ETH")));
```